### PR TITLE
🐛 fix(workflow): add write permissions for id-token and pages

### DIFF
--- a/.github/workflows/ci-deploy-pages.yml
+++ b/.github/workflows/ci-deploy-pages.yml
@@ -102,6 +102,9 @@ jobs:
     if: ${{ ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'sphinx-build-docs' ) ) ||
               ( github.event_name == 'workflow_dispatch' ) }}
+    permissions:
+      id-token: write
+      pages: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.client_payload.BUILD_RUN_ID || inputs.BUILD_RUN_ID }}
       cancel-in-progress: true


### PR DESCRIPTION
Added write permissions for 'id-token' and 'pages' in the 'caller' job of the 'ci-deploy-pages' workflow because the nested job 'deploy-pages' of the calling workflow 'use-deploy-pages.yml' requests permissions: 'pages: write, id-token: write'.