### PR TITLE
🔧 chore(script): refine comments and messages

### DIFF
--- a/cmake/custom/crowdin.yml
+++ b/cmake/custom/crowdin.yml
@@ -20,7 +20,7 @@ languages_mapping: &languages_mapping
     zh-TW:  zh_TW
 
 #
-# Files configuration
+# Files configuration.
 #
 files:
   - source: /locale/pot/**/*.pot

--- a/cmake/targets/sphinx_update_pot.cmake
+++ b/cmake/targets/sphinx_update_pot.cmake
@@ -226,7 +226,7 @@ else()
 endif()
 
 
-message(STATUS "Removing '${PROJ_OUT_REPO_DOCS_LOCALE_DIR}/' directory...")
+message(STATUS "Removing directory '${PROJ_OUT_REPO_DOCS_LOCALE_DIR}/'...")
 if (EXISTS "${PROJ_OUT_REPO_DOCS_LOCALE_DIR}")
     file(REMOVE_RECURSE "${PROJ_OUT_REPO_DOCS_LOCALE_DIR}")
     remove_cmake_message_indent()

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -20,7 +20,7 @@ languages_mapping: &languages_mapping
     zh-TW:  zh_TW
 
 #
-# Files configuration
+# Files configuration.
 #
 files:
   - source: /README.md


### PR DESCRIPTION
- Refined comments in 'crowdin.yml' and 'cmake/custom/crowdin.yml'.
- Refined status message in 'cmake/targets/sphinx_update_pot.cmake'.