### PR TITLE
✨ feat(workflow): restrict jobs to specific repository

### DIFF
--- a/.github/workflows/ci-check-pr-status.yml
+++ b/.github/workflows/ci-check-pr-status.yml
@@ -15,6 +15,13 @@ on:
 
 jobs:
   before-check:
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name   == 'pull_request' ) &&
+              ( github.base_ref     == 'main' ||
+                github.base_ref     == 'l10n' ) &&
+              ( github.event.action == 'opened' ||
+                github.event.action == 'synchronize' ||
+                github.event.action == 'reopened' ) ) }}
     runs-on: ubuntu-latest
     outputs:
       WORKFLOW_CHANGE: ${{ steps.filter.outputs.workflow }}
@@ -71,6 +78,7 @@ jobs:
               - 'languages.json'
               - 'versions.json'
       - name: Check Outputs of paths-filter
+        shell: bash
         run: |
           echo "steps.filter.outputs.workflow = ${{ steps.filter.outputs.workflow }}"
           echo "steps.filter.outputs.document = ${{ steps.filter.outputs.document }}"
@@ -81,6 +89,13 @@ jobs:
 
   check-crowdin-update-docs:
     needs: [ 'before-check' ]
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name   == 'pull_request' ) &&
+              ( github.base_ref     == 'main' ||
+                github.base_ref     == 'l10n' ) &&
+              ( github.event.action == 'opened' ||
+                github.event.action == 'synchronize' ||
+                github.event.action == 'reopened' ) ) }}
     uses: localizethedocs/ci-common/.github/workflows/use-crowdin-update-docs.yml@main
     with:
       ENABLE: ${{ needs.before-check.outputs.DOCUMENT_CHANGE == 'true' }}
@@ -102,6 +117,13 @@ jobs:
 
   check-sphinx-build-docs:
     needs: [ 'before-check' ]
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name   == 'pull_request' ) &&
+              ( github.base_ref     == 'main' ||
+                github.base_ref     == 'l10n' ) &&
+              ( github.event.action == 'opened' ||
+                github.event.action == 'synchronize' ||
+                github.event.action == 'reopened' ) ) }}
     uses: localizethedocs/ci-common/.github/workflows/use-sphinx-build-docs.yml@main
     with:
       ENABLE: ${{ needs.before-check.outputs.SCRIPT_CHANGE == 'true' }}

--- a/.github/workflows/ci-crowdin-download-po.yml
+++ b/.github/workflows/ci-crowdin-download-po.yml
@@ -56,7 +56,8 @@ env:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
@@ -145,7 +146,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     outputs:
@@ -186,7 +188,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     strategy:

--- a/.github/workflows/ci-crowdin-update-docs.yml
+++ b/.github/workflows/ci-crowdin-update-docs.yml
@@ -26,7 +26,8 @@ on:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'push' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'push' ) ||
               ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
@@ -113,7 +114,8 @@ jobs:
 
   caller:
     needs: [ 'precondition' ]
-    if: ${{ ( ( github.event_name == 'push' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'push' ) ||
               ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     concurrency:

--- a/.github/workflows/ci-crowdin-upload-pot.yml
+++ b/.github/workflows/ci-crowdin-upload-pot.yml
@@ -36,7 +36,8 @@ on:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'repository_dispatch' &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'pr-merged-to-l10n' &&
                 github.event.client_payload.CROWDIN == 'true' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
@@ -110,8 +111,8 @@ jobs:
           fi
 
   get-matrix:
-    needs: [ 'precondition' ]
-    if: ${{ ( ( github.event_name == 'repository_dispatch' &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'pr-merged-to-l10n' &&
                 github.event.client_payload.CROWDIN == 'true' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
@@ -141,8 +142,9 @@ jobs:
           version-array: ${{ steps.gvlv.outputs.VERSION_ARRAY }}
 
   caller:
-    needs: [ 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    needs: [ 'precondition', 'get-matrix' ]
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'pr-merged-to-l10n' &&
                 github.event.client_payload.CROWDIN == 'true' ) ||

--- a/.github/workflows/ci-deploy-pages.yml
+++ b/.github/workflows/ci-deploy-pages.yml
@@ -27,6 +27,10 @@ on:
 
 jobs:
   precondition:
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'repository_dispatch' &&
+                github.event.action == 'sphinx-build-docs' ) ) ||
+              ( github.event_name == 'workflow_dispatch' ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Print Contexts/Inputs/Variables/Secrets
@@ -99,7 +103,8 @@ jobs:
 
   caller:
     needs: [ 'precondition' ]
-    if: ${{ ( ( github.event_name == 'repository_dispatch' &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'sphinx-build-docs' ) ) ||
               ( github.event_name == 'workflow_dispatch' ) }}
     permissions:

--- a/.github/workflows/ci-deploy-po-version.yml
+++ b/.github/workflows/ci-deploy-po-version.yml
@@ -42,7 +42,8 @@ env:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
@@ -114,7 +115,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     outputs:
@@ -149,7 +151,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     strategy:

--- a/.github/workflows/ci-gettext-compendium.yml
+++ b/.github/workflows/ci-gettext-compendium.yml
@@ -47,7 +47,8 @@ env:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
@@ -120,7 +121,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     outputs:
@@ -161,7 +163,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     strategy:

--- a/.github/workflows/ci-gettext-statistics.yml
+++ b/.github/workflows/ci-gettext-statistics.yml
@@ -42,6 +42,9 @@ env:
 
 jobs:
   precondition:
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
+              ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Print Contexts/Inputs/Variables/Secrets
@@ -112,7 +115,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     outputs:
@@ -147,7 +151,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     strategy:

--- a/.github/workflows/ci-gettext-update-po.yml
+++ b/.github/workflows/ci-gettext-update-po.yml
@@ -50,6 +50,11 @@ on:
 
 jobs:
   precondition:
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'repository_dispatch' &&
+                github.event.action == 'pr-merged-to-l10n' &&
+                github.event.client_payload.GETTEXT == 'true' ) ||
+              ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Print Contexts/Inputs/Variables/Secrets
@@ -127,7 +132,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'repository_dispatch' &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'pr-merged-to-l10n' &&
                 github.event.client_payload.GETTEXT == 'true' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
@@ -164,7 +170,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'repository_dispatch' &&
                 github.event.action == 'pr-merged-to-l10n' &&
                 github.event.client_payload.GETTEXT == 'true' ) ||

--- a/.github/workflows/ci-sphinx-build-docs.yml
+++ b/.github/workflows/ci-sphinx-build-docs.yml
@@ -55,7 +55,8 @@ env:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
@@ -119,7 +120,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     outputs:
@@ -160,7 +162,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     strategy:
@@ -187,7 +190,8 @@ jobs:
 
   dispatch:
     needs: [ 'caller' ]
-    if: ${{ ( inputs.DEPLOY_PAGES != 'false' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( inputs.DEPLOY_PAGES != 'false' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}

--- a/.github/workflows/ci-sphinx-update-pot.yml
+++ b/.github/workflows/ci-sphinx-update-pot.yml
@@ -51,6 +51,9 @@ env:
 
 jobs:
   precondition:
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
+              ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Print Contexts/Inputs/Variables/Secrets
@@ -122,7 +125,8 @@ jobs:
           fi
 
   get-matrix:
-    if: ${{ ( ( github.event_name == 'schedule' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
     outputs:
@@ -157,7 +161,8 @@ jobs:
 
   caller:
     needs: [ 'precondition', 'get-matrix' ]
-    if: ${{ ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( needs.get-matrix.outputs.MATRIX_NUM != '0' ) &&
             ( ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     strategy:

--- a/.github/workflows/ci-update-license-year.yml
+++ b/.github/workflows/ci-update-license-year.yml
@@ -18,7 +18,8 @@ on:
 
 jobs:
   precondition:
-    if: ${{ ( ( github.event_name == 'push' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'push' ) ||
               ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     runs-on: ${{ vars.RUNNER }}
@@ -89,7 +90,8 @@ jobs:
 
   caller:
     needs: [ 'precondition' ]
-    if: ${{ ( ( github.event_name == 'push' ) ||
+    if: ${{ ( github.repository == 'localizethedocs/cmake-docs-l10n' ) &&
+            ( ( github.event_name == 'push' ) ||
               ( github.event_name == 'schedule' ) ||
               ( github.event_name == 'workflow_dispatch' ) ) }}
     concurrency:


### PR DESCRIPTION
- Updated precondition checks in multiple workflow files.
- Ensured jobs only run for 'localizethedocs/cmake-docs-l10n' repository.
- Updated conditions for pull requests, schedules, and dispatch events.