### PR TITLE
🐛 fix(readme): fix column span in project links table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This is a localization project of CMake Documentation. Translations are contribu
 <table>
   <thead>
     <tr>
-      <th rowspan="1" colspan="3" align="center" style="text-align: center;"><div>Project Links</div></th>
+      <th rowspan="1" colspan="2" align="center" style="text-align: center;"><div>Project Links</div></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Fixed column span of header in project links table from "3" to "2".