### PR TITLE
♻️ refactor(script): improve find_package search paths

### DIFF
--- a/cmake/targets/create_rtd_symlinks.cmake
+++ b/cmake/targets/create_rtd_symlinks.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 include(LogUtils)
 include(JsonUtils)
 

--- a/cmake/targets/crowdin_download_po.cmake
+++ b/cmake/targets/crowdin_download_po.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgmerge)
 find_package(Crowdin    MODULE REQUIRED)
 include(LogUtils)

--- a/cmake/targets/crowdin_upload_po.cmake
+++ b/cmake/targets/crowdin_upload_po.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgmerge)
 find_package(Crowdin    MODULE REQUIRED)
 include(LogUtils)

--- a/cmake/targets/crowdin_upload_pot.cmake
+++ b/cmake/targets/crowdin_upload_pot.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Crowdin    MODULE REQUIRED)
 include(LogUtils)
 

--- a/cmake/targets/gettext_compendium.cmake
+++ b/cmake/targets/gettext_compendium.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgcat Msgmerge)
 include(LogUtils)
 include(GettextUtils)

--- a/cmake/targets/gettext_statistics.cmake
+++ b/cmake/targets/gettext_statistics.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgattrib)
 include(LogUtils)
 include(JsonUtils)

--- a/cmake/targets/gettext_update_po.cmake
+++ b/cmake/targets/gettext_update_po.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Git        MODULE REQUIRED)
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgcat Msgmerge)
 include(LogUtils)

--- a/cmake/targets/install_requirements.cmake
+++ b/cmake/targets/install_requirements.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Git        MODULE REQUIRED)
 find_package(Conda      MODULE REQUIRED)
 include(LogUtils)
@@ -172,7 +174,6 @@ message("")
 restore_cmake_message_indent()
 
 
-set(Python_ROOT_DIR     "${PROJ_CONDA_DIR}")
 find_package(Python     MODULE REQUIRED)
 message(STATUS "Running 'python -c \"import sys; print('\\n'.join(sys.path))\"' command to check python system paths...")
 remove_cmake_message_indent()
@@ -185,7 +186,6 @@ message("")
 restore_cmake_message_indent()
 
 
-set(Sphinx_ROOT_DIR     "${PROJ_CONDA_DIR}")
 find_package(Sphinx     MODULE REQUIRED)
 
 

--- a/cmake/targets/prepare_repositories.cmake
+++ b/cmake/targets/prepare_repositories.cmake
@@ -9,6 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Git        MODULE REQUIRED)
 include(LogUtils)
 include(GitUtils)

--- a/cmake/targets/sphinx_build_docs.cmake
+++ b/cmake/targets/sphinx_build_docs.cmake
@@ -9,7 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
-set(Sphinx_ROOT_DIR     "${PROJ_CONDA_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Git        MODULE REQUIRED)
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgcat Msgmerge)
 find_package(Sphinx     MODULE REQUIRED COMPONENTS Build)

--- a/cmake/targets/sphinx_update_pot.cmake
+++ b/cmake/targets/sphinx_update_pot.cmake
@@ -9,9 +9,8 @@ message(STATUS "-------------------- ${SCRIPT_NAME} --------------------")
 
 
 set(CMAKE_MODULE_PATH   "${PROJ_CMAKE_MODULES_DIR}")
-set(CMake_ROOT_DIR      "${PROJ_CONDA_DIR}")
-set(Python_ROOT_DIR     "${PROJ_CONDA_DIR}")
-set(Sphinx_ROOT_DIR     "${PROJ_CONDA_DIR}")
+set(CMAKE_PROGRAM_PATH  "${PROJ_CONDA_DIR}"
+                        "${PROJ_CONDA_DIR}/Library")
 find_package(Git        MODULE REQUIRED)
 find_package(Gettext    MODULE REQUIRED COMPONENTS Msgcat Msgmerge)
 find_package(CMake      MODULE REQUIRED)


### PR DESCRIPTION
Replaced `*_ROOT_DIR` variables with `CMAKE_PROGRAM_PATH` variable.