### PR TITLE
✨ feat(script): add BRANCH_OF_WORKTREE cache entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ set(GETTEXT_WRAP_WIDTH 79
     # See https://www.gnu.org/software/gettext/manual/html_node/msgcat-Invocation.html
     # and https://www.gnu.org/software/gettext/manual/html_node/msgmerge-Invocation.html for details.
 
+set(BRANCH_OF_WORKTREE "l10n"
+    CACHE STRING "The branch of the 'l10n' git worktree.")
+
 set(REMOTE_URL_OF_L10N "https://github.com/localizethedocs/cmake-docs-l10n.git"
     CACHE STRING "The remote URL of the 'l10n' repository.")
 
@@ -354,6 +357,7 @@ find_package(Crowdin    MODULE QUIET)
 #]============================================================]
 
 create_git_worktree_for_l10n_branch(
+    IN_BRANCH           "${BRANCH_OF_WORKTREE}"
     IN_REMOTE_URL       "${REMOTE_URL_OF_L10N}"
     IN_LOCAL_PATH       "${PROJ_SOURCE_DIR}"
     IN_WORKTREE_PATH    "${PROJ_L10N_DIR}")
@@ -402,6 +406,7 @@ message(STATUS "SPHINX_VERBOSE_LEVEL            = ${SPHINX_VERBOSE_LEVEL}")
 message(STATUS "SPHINX_GETTEXT_COMPACT          = ${SPHINX_GETTEXT_COMPACT}")
 message(STATUS "SPHINX_GETTEXT_TARGETS          = ${SPHINX_GETTEXT_TARGETS}")
 message(STATUS "GETTEXT_WRAP_WIDTH              = ${GETTEXT_WRAP_WIDTH}")
+message(STATUS "BRANCH_OF_WORKTREE              = ${BRANCH_OF_WORKTREE}")
 message(STATUS "REMOTE_URL_OF_L10N              = ${REMOTE_URL_OF_L10N}")
 message(STATUS "REMOTE_URL_OF_DOCS              = ${REMOTE_URL_OF_DOCS}")
 message(STATUS "BASEURL_HREF                    = ${BASEURL_HREF}")
@@ -503,6 +508,7 @@ set(SCRIPT_MODE_CACHE
     -D SPHINX_GETTEXT_COMPACT=${SPHINX_GETTEXT_COMPACT}
     -D SPHINX_GETTEXT_TARGETS=${SPHINX_GETTEXT_TARGETS}
     -D GETTEXT_WRAP_WIDTH=${GETTEXT_WRAP_WIDTH}
+    -D BRANCH_OF_WORKTREE=${BRANCH_OF_WORKTREE}
     -D REMOTE_URL_OF_L10N=${REMOTE_URL_OF_L10N}
     -D REMOTE_URL_OF_DOCS=${REMOTE_URL_OF_DOCS}
     -D BASEURL_HREF=${BASEURL_HREF}


### PR DESCRIPTION
- Added BRANCH_OF_WORKTREE cache entry for the branch of the worktree.
- Updated create_git_worktree_for_l10n_branch to use this cache entry.
- Updated status message to display the branch of worktree.