### PR TITLE
🔧 chore(gitmodules): update plugin submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = main
 [submodule "cmake/plugins"]
 	path = cmake/plugins
-	url = ../../localizethedocs/plugins
+	url = ../../localizethedocs/plugins.git
 	branch = main


### PR DESCRIPTION
Changed the URL for the `cmake/plugins` submodule to include the `.git` extension for consistency with other submodule definitions.