### PR TITLE
♻️ refactor(script): use python -m site for sys.path check

### DIFF
--- a/cmake/targets/install_requirements.cmake
+++ b/cmake/targets/install_requirements.cmake
@@ -175,11 +175,12 @@ restore_cmake_message_indent()
 
 
 find_package(Python     MODULE REQUIRED)
-message(STATUS "Running 'python -c \"import sys; print('\\n'.join(sys.path))\"' command to check python system paths...")
+message(STATUS "Running 'python -m site' command to check python system paths...")
 remove_cmake_message_indent()
 message("")
 execute_process(
-    COMMAND ${Python_EXECUTABLE} -c "import sys; print('\\n'.join(sys.path))"
+    COMMAND ${Python_EXECUTABLE} -m site
+    WORKING_DIRECTORY ${PROJ_OUT_REPO_DIR}
     ECHO_OUTPUT_VARIABLE
     ECHO_ERROR_VARIABLE)
 message("")


### PR DESCRIPTION
Change the command used to check Python system paths from `python -c "import sys; print('\n'.join(sys.path))"` to `python -m site`.

Synced from: https://github.com/localizethedocs/python-docs-l10n/commit/e50d7bf94adf13e269e08e4986c065732c54bf6b