### PR TITLE
🎨 style(readme): update cmake dark/light logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 <picture>
-  <img height="100" src="https://cdn.jsdelivr.net/gh/localizethedocs/static/mark/cmake.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/localizethedocs/static/logo/cmake-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://cdn.jsdelivr.net/gh/localizethedocs/static/logo/cmake-light.svg">
+  <img height="100" src="https://cdn.jsdelivr.net/gh/localizethedocs/static/logo/cmake-light.svg">
 </picture>
 </div>
 


### PR DESCRIPTION
- Use 'logo/cmake-dark.svg' for dark theme.
- Use 'logo/cmake-light.svg' for light theme.